### PR TITLE
Fixed Issue #229: Menu and Navbar missing on tools landing page /tools/

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,7 +1,12 @@
 ---
+sidebar_position: 1
 title: Development Tools
-description: Summary of tools built for development on Unlock Protocol.
+pagination_next: tools/dashboard
+description: >-
+  Summary of tools built for development on Unlock Protocol.
 ---
+<!-- added pagination to footer -->
+
 # Tools
 
 Unlock Labs maintains a set of development tools to interact with Unlock Protocol.

--- a/sidebars.js
+++ b/sidebars.js
@@ -61,6 +61,10 @@ const sidebars = {
     {
       label: "Tools",
       type: "category",
+      link: { //added link tag to display sidebar on tools page
+        type: "doc",
+        id: "tools/README",
+      },      
       items: [
         "tools/dashboard",
         {


### PR DESCRIPTION
### Description
Added missing Sidebar/Navigation bar on /tools/ page

### Issue
Fixed: #229 
