### PR TITLE
Fixed Docs Issue #234: Add redirect for sign in with Ethereum page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -29,7 +29,7 @@ const config = {
         redirects: [
           {
             from: "/unlock/developers/sign-in-with-ethereum", //redirect sign in with ethereum
-            to: "/tools/sign-in-with-ethereum",
+            to: "/tools/sign-in-with-ethereum/",
           },
           {
             from: "/unlock",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,6 +28,10 @@ const config = {
       {
         redirects: [
           {
+            from: "/unlock/developers/sign-in-with-ethereum", //redirect sign in with ethereum
+            to: "/tools/sign-in-with-ethereum",
+          },
+          {
             from: "/unlock",
             to: "/",
           },


### PR DESCRIPTION
### Description
1) Added redirect for `Sign In With Ethereum` 404 error page from https://docs.unlock-protocol.com/unlock/developers/sign-in-with-ethereum to https://docs.unlock-protocol.com/tools/sign-in-with-ethereum/ 

### Issue
Fixed: #234 