### PR TITLE
Fixed Docs Issue #240: Add Cancel is enabled to docs

### DIFF
--- a/docs/core-protocol/smart-contracts-api/PublicLock.md
+++ b/docs/core-protocol/smart-contracts-api/PublicLock.md
@@ -153,10 +153,9 @@ Deactivate an existing keythe key will be expired and ownership records will be 
 ```solidity
 function cancelAndRefund(uint256 _tokenId) external nonpayable
 ```
+*Allows the key manager to expire a given tokenId and send a refund to the keyOwner based on the amount of time remaining.*
 
-
-
-*allows the key manager to expire a given tokenId and send a refund to the keyOwner based on the amount of time remaining.*
+> Note: _Cancel is enabled with a 10% penalty by default on all Locks._
 
 #### Parameters
 


### PR DESCRIPTION
### Description
Added `Cancel is enabled with a 10% penalty by default on all Locks` to docs at `https://docs.unlock-protocol.com/core-protocol/smart-contracts-api/publiclock/#cancelandrefund`

### Issue
Fixed: #240 