### PR TITLE
adding doc on minting keys

### DIFF
--- a/docs/core-protocol/public-lock/access-control.md
+++ b/docs/core-protocol/public-lock/access-control.md
@@ -3,7 +3,7 @@ title: Contract Management
 description: >-
   A description of the updated contract management system for Unlock Protocol "Lock"
   contracts.
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Contract Management

--- a/docs/core-protocol/public-lock/hooks.md
+++ b/docs/core-protocol/public-lock/hooks.md
@@ -2,7 +2,7 @@
 title: Hooks
 description: >-
   The "Lock" contract includes hooks that let developers customize their behavior.
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Hooks
@@ -20,6 +20,7 @@ We currently support 7 hooks (as of v12). If your lock uses a previous version, 
 - <a href="#onkeytransferhook-hook">onKeyTransferHook</a>: called when a key is transfered from an address to another.
 
 ## onGrantKey Hook
+
 The `onGrantKeyHook` allows you to create custom logic that is called each time a key is granted. This could enable use cases to create custom logic when keys are granted outside of a purchase flow.
 
 A KeyGrantedHook should implement the following interface.
@@ -46,7 +47,9 @@ interface ILockKeyGrantHook
   ) external;
 }
 ```
+
 ## onKeyExtend Hook
+
 The `onKeyExtendHook` allows you create custom logic when a key is extended or renewed. This could enable use cases where for instance key metadata is updated, maybe you want to update the image when renewals happen. It could enable rewards programs where you increment a reward point total everytime a membership is renewed.
 
 A KeyExtendHook should implement the following interface.
@@ -69,6 +72,7 @@ interface ILockKeyExtendHook
   ) external;
 }
 ```
+
 ## OnKeyPurchase Hook
 
 The `onKeyPurchaseHook` allows you to create custom purchase logic, for instance dynamic pricing, etc.

--- a/docs/core-protocol/public-lock/minting-keys.md
+++ b/docs/core-protocol/public-lock/minting-keys.md
@@ -26,7 +26,7 @@ Another argument is an array of key managers. The [key manager](/core-protocol/p
 
 The Lock contract also has a [`grantKeys`](/core-protocol/smart-contracts-api/PublicLock#grantkeys) method. This method can _only_ be called by [lock managers](/core-protocol/public-lock/access-control#lockmanager) or [key granters](/core-protocol/public-lock/access-control#keygranter) and can be used to mint/grant keys _for free_. This function does **not require** a payment and is not limited by the maximum number of keys for sale.
 
-Contrary to the previous method, the granter can also customize the expiration of each membership minted using this, which makes it a convenient method to grant _previews_ or free trials. However, there again, it is critical to set the [key manager](/core-protocol/public-lock/access-control#keymanager) accordingly in order to avoid abuses. For example, if the contract allows for refunds upon cancellation, a malicious recipient of a key airdroped could then claim a refund if they have also been set as _key manager_.
+Contrary to the previous method, the granter can also customize the expiration of each membership minted using this mechanism, which makes it a convenient method to grant _previews_ or free trials. However, there again, it is critical to set the [key manager](/core-protocol/public-lock/access-control#keymanager) accordingly in order to avoid abuses. For example, if the contract allows for refunds upon cancellation, a malicious recipient of a key airdroped could then claim a refund if they have also been set as _key manager_.
 
 ### Renewals and extensions
 

--- a/docs/core-protocol/public-lock/minting-keys.md
+++ b/docs/core-protocol/public-lock/minting-keys.md
@@ -16,7 +16,7 @@ Let's start by noting that this flow uses the function [`purchase`](/core-protoc
 Note: To disable purchases completely, the best approach is to set the maximum number of keys available for sale to be `0`.
 :::
 
-The `purchase` function can be used to purchase multiple keys at once, and the function takes arguments whichg are all `arrays` in order to accomodate this. Each of these arrays needs to be of the same size.
+The `purchase` function can be used to purchase multiple keys at once, and the function takes arguments which are all `arrays` in order to accommodate this. Each of these arrays needs to be of the same size.
 
 One of the arguments is an array of recipients, which means that the wallet sending the transaction can be _different_ from the one who will receive the NFT memberships. This can be very useful when application is buying on behalf of users for examples, or when a payment happens "off-chain" (using credit card or other mechanism) and the payment provider then wants to mint the NFT membership to the user.
 

--- a/docs/core-protocol/public-lock/minting-keys.md
+++ b/docs/core-protocol/public-lock/minting-keys.md
@@ -26,7 +26,7 @@ Another argument is an array of key managers. The [key manager](/core-protocol/p
 
 The Lock contract also has a [`grantKeys`](/core-protocol/smart-contracts-api/PublicLock#grantkeys) method. This method can _only_ be called by [lock managers](/core-protocol/public-lock/access-control#lockmanager) or [key granters](/core-protocol/public-lock/access-control#keygranter) and can be used to mint/grant keys _for free_. This function does **not require** a payment and is not limited by the maximum number of keys for sale.
 
-Contrary to the previous method, the granter can also customize the expiration of each membership minted using this mechanism, which makes it a convenient method to grant _previews_ or free trials. However, there again, it is critical to set the [key manager](/core-protocol/public-lock/access-control#keymanager) accordingly in order to avoid abuses. For example, if the contract allows for refunds upon cancellation, a malicious recipient of a key airdroped could then claim a refund if they have also been set as _key manager_.
+Contrary to the previous method, the granter can also customize the expiration of each membership minted using this mechanism, which makes it a convenient method to grant _previews_ or free trials. However, there again, it is critical to set the [key manager](/core-protocol/public-lock/access-control#keymanager) accordingly in order to avoid abuses. For example, if the contract allows for refunds upon cancellation, a malicious recipient of an airdropped key could then claim a refund if they have also been set as _key manager_.
 
 ### Renewals and extensions
 

--- a/docs/core-protocol/public-lock/minting-keys.md
+++ b/docs/core-protocol/public-lock/minting-keys.md
@@ -35,5 +35,5 @@ When a Key is renewed, the Key's expiration date is extended so the Key is consi
 For renewals and extensions, each NFT needs to be extended individually. However, they can be extended using different methods:
 
 - [`extend`](/core-protocol/smart-contracts-api/PublicLock#extend) where the sender of the transaction _pays_ for the extension, even if they are not the owner of the NFT itself. It is advised here again to carefuly consider the key manager.
-- [`renewMembershipFor`](/core-protocol/smart-contracts-api/PublicLock#renewmembershipfor) which can only be called for ERC20 locks where the owner has approved the renewals through and ERC20 approval as _their_ balance will be reduced.
+- [`renewMembershipFor`](/core-protocol/smart-contracts-api/PublicLock#renewmembershipfor) which can only be called for ERC20 locks where the owner has approved the renewals through an ERC20 approval as _their_ balance will be reduced.
 - [`grantKeyExtension`](/core-protocol/smart-contracts-api/PublicLock#grantkeyextension) which is similar to `grantKeys` and can only be called by lock managers or key granters.

--- a/docs/core-protocol/public-lock/minting-keys.md
+++ b/docs/core-protocol/public-lock/minting-keys.md
@@ -18,7 +18,7 @@ Note: To disable purchases completely, the best approach is to set the maximum n
 
 The `purchase` function can be used to purchase multiple keys at once, and the function takes arguments which are all `arrays` in order to accommodate this. Each of these arrays needs to be of the same size.
 
-One of the arguments is an array of recipients, which means that the wallet sending the transaction can be _different_ from the one who will receive the NFT memberships. This can be very useful when application is buying on behalf of users for examples, or when a payment happens "off-chain" (using credit card or other mechanism) and the payment provider then wants to mint the NFT membership to the user.
+One of the arguments is an array of recipients, which means that the wallet sending the transaction can be _different_ from the one who will receive the NFT memberships. This can be very useful when, for example, the application is buying on behalf of users or when a payment happens "off-chain" (using credit card or other mechanism) and the payment provider then wants to mint the NFT membership to the user.
 
 Another argument is an array of key managers. The [key manager](/core-protocol/public-lock/access-control#keymanager) is the address that has the transfer and cancellation rights over the NFT being minted. For credit card purchases where the transaction cannot be considered final, we strongly advise this key manager to be controlled by the entity that triggered the card payment so that if the transaction is reversed, the NFT membership can also be cancelled.
 

--- a/docs/core-protocol/public-lock/minting-keys.md
+++ b/docs/core-protocol/public-lock/minting-keys.md
@@ -10,7 +10,7 @@ There are two methods that can be used to mint Keys. Keys can either be **purcha
 
 ### Purchasing Keys
 
-Let's start by noting that this flow is uses the function [`purchase`](/core-protocol/smart-contracts-api/PublicLock#purchase) from the lock even if the keys are free. The best way to describe this flow is that it is _self-served_, which means that anyone can call this function to mint an NFT, whether these keys are free or paid.
+Let's start by noting that this flow uses the function [`purchase`](/core-protocol/smart-contracts-api/PublicLock#purchase) from the lock even if the keys are free. The best way to describe this flow is that it is _self-served_, which means that anyone can call this function to mint an NFT, whether these keys are free or paid.
 
 :::info
 Note: To disable purchases completely, the best approach is to set the maximum number of keys available for sale to be `0`.

--- a/docs/core-protocol/public-lock/minting-keys.md
+++ b/docs/core-protocol/public-lock/minting-keys.md
@@ -30,7 +30,9 @@ Contrary to the previous method, the granter can also customize the expiration o
 
 ### Renewals and extensions
 
-No new key or membership tokens are created upon renewals, their expiration is extended so that they are considered valid for a longer duration. For renewals and extension, each NFT needs to be extended one by one. However, there again, they can be extended using different methods:
+When a Key is renewed, the Key's expiration date is extended so the Key is considered valid for a longer duration. No new keys or membership tokens are created upon renewals. 
+
+For renewals and extensions, each NFT needs to be extended individually. However, they can be extended using different methods:
 
 - [`extend`](/core-protocol/smart-contracts-api/PublicLock#extend) where the sender of the transaction _pays_ for the extension, even if they are not the owner of the NFT itself. It is advised here again to carefuly consider the key manager.
 - [`renewMembershipFor`](/core-protocol/smart-contracts-api/PublicLock#renewmembershipfor) which can only be called for ERC20 locks where the owner has approved the renewals through and ERC20 approval as _their_ balance will be reduced.

--- a/docs/core-protocol/public-lock/minting-keys.md
+++ b/docs/core-protocol/public-lock/minting-keys.md
@@ -4,7 +4,9 @@ description: Membership NFTs are called keys and they can be minted from the Loc
 sidebar_position: 2
 ---
 
-Keys are the Membership Non Fungible Tokens. They are minted from the Lock contract and there exists 2 methods to mint them: they can either be **purchased** or **granted**. Both of these can be used to mint keys one by one or multiple at a time.
+In the Unlock Protocol ecosystem, Membership Non Fungible Tokens are called [Keys](https://unlock-protocol.com/guides/locksmith-lingo/). Keys are minted from the Lock contract.
+
+There are two methods that can be used to mint Keys. Keys can either be **purchased** or **granted**. Keys can be minted one-by-one or in batches (multiple Keys minted at one time) using either method.
 
 ### Purchasing Keys
 

--- a/docs/core-protocol/public-lock/minting-keys.md
+++ b/docs/core-protocol/public-lock/minting-keys.md
@@ -1,0 +1,35 @@
+---
+title: Minting Keys
+description: Membership NFTs are called keys and they can be minted from the Lock contract using two different methods.
+sidebar_position: 2
+---
+
+Keys are the Membership Non Fungible Tokens. They are minted from the Lock contract and there exists 2 methods to mint them: they can either be **purchased** or **granted**. Both of these can be used to mint keys one by one or multiple at a time.
+
+### Purchasing Keys
+
+Let's start by noting that this flow is uses the function [`purchase`](/core-protocol/smart-contracts-api/PublicLock#purchase) from the lock even if the keys are free. The best way to describe this flow is that it is _self-served_, which means that anyone can call this function to mint an NFT, whether these keys are free or paid.
+
+:::info
+Note: To disable purchases completely, the best approach is to set the maximum number of keys available for sale to be `0`.
+:::
+
+The `purchase` function can be used to purchase multiple keys at once, and the function takes arguments whichg are all `arrays` in order to accomodate this. Each of these arrays needs to be of the same size.
+
+One of the arguments is an array of recipients, which means that the wallet sending the transaction can be _different_ from the one who will receive the NFT memberships. This can be very useful when application is buying on behalf of users for examples, or when a payment happens "off-chain" (using credit card or other mechanism) and the payment provider then wants to mint the NFT membership to the user.
+
+Another argument is an array of key managers. The [key manager](/core-protocol/public-lock/access-control#keymanager) is the address that has the transfer and cancellation rights over the NFT being minted. For credit card purchases where the transaction cannot be considered final, we strongly advise this key manager to be controlled by the entity that triggered the card payment so that if the transaction is reversed, the NFT membership can also be cancelled.
+
+### Granting Keys
+
+The Lock contract also has a [`grantKeys`](/core-protocol/smart-contracts-api/PublicLock#grantkeys) method. This method can _only_ be called by [lock managers](/core-protocol/public-lock/access-control#lockmanager) or [key granters](/core-protocol/public-lock/access-control#keygranter) and can be used to mint/grant keys _for free_. This function does **not require** a payment and is not limited by the maximum number of keys for sale.
+
+Contrary to the previous method, the granter can also customize the expiration of each membership minted using this, which makes it a convenient method to grant _previews_ or free trials. However, there again, it is critical to set the [key manager](/core-protocol/public-lock/access-control#keymanager) accordingly in order to avoid abuses. For example, if the contract allows for refunds upon cancellation, a malicious recipient of a key airdroped could then claim a refund if they have also been set as _key manager_.
+
+### Renewals and extensions
+
+No new key or membership tokens are created upon renewals, their expiration is extended so that they are considered valid for a longer duration. For renewals and extension, each NFT needs to be extended one by one. However, there again, they can be extended using different methods:
+
+- [`extend`](/core-protocol/smart-contracts-api/PublicLock#extend) where the sender of the transaction _pays_ for the extension, even if they are not the owner of the NFT itself. It is advised here again to carefuly consider the key manager.
+- [`renewMembershipFor`](/core-protocol/smart-contracts-api/PublicLock#renewmembershipfor) which can only be called for ERC20 locks where the owner has approved the renewals through and ERC20 approval as _their_ balance will be reduced.
+- [`grantKeyExtension`](/core-protocol/smart-contracts-api/PublicLock#grantkeyextension) which is similar to `grantKeys` and can only be called by lock managers or key granters.

--- a/docs/tools/checkout/configuration.md
+++ b/docs/tools/checkout/configuration.md
@@ -86,7 +86,3 @@ Make sure you use a number and not a string! For the complete list check our
     ]
 }
 ```
-
-:::info
-[Kalidou](https://twitter.com/kld_diagne) from our team built a [tool](https://app.unlock-protocol.com/locks/checkout-url) for generating these json configuration files and encoded urls.
-:::


### PR DESCRIPTION
Adding a "generic" doc on how to mint keys. This should be a good start for teams that want to integrate minting a lock's keys as part of their credit card checkout flows for example